### PR TITLE
Fixed missing parameter when calling vep function when converting from maf

### DIFF
--- a/makevariantsdb/makevariantsdb.py
+++ b/makevariantsdb/makevariantsdb.py
@@ -70,7 +70,7 @@ class generateVarDB:
         # mapping process
         var_infile = out_file
         self.vep(
-            var_infile, vardb_outdir, overwrite, log_dir, parallel)
+            var_infile, vardb_outdir, overwrite, log_dir, sort, parallel, njobs)
         # logging
         self.log('Splitting process is done.',
                  report, logger)


### PR DESCRIPTION
Added sort and njobs parameter when calling vep when calling `vep()` from `self.maf()` function